### PR TITLE
Configuration Allowing Null For Default Enum Deserialization

### DIFF
--- a/src/main/java/com/taboola/rest/api/internal/config/SerializationConfig.java
+++ b/src/main/java/com/taboola/rest/api/internal/config/SerializationConfig.java
@@ -8,6 +8,7 @@ public class SerializationConfig {
     private boolean shouldIgnoreAnySetterAnnotation;
     private boolean shouldDisableReadUnknownEnumValuesAsDefaultValue;
     private boolean shouldUseSnakeCase;
+    private boolean shouldAllowNullAsDefaultValueForReadUnknownEnums;
 
     public SerializationConfig() {
         mixins = new HashMap<>();
@@ -36,6 +37,11 @@ public class SerializationConfig {
         return this;
     }
 
+    public SerializationConfig setShouldAllowNullAsDefaultValueForReadUnknownEnums() {
+        this.shouldAllowNullAsDefaultValueForReadUnknownEnums = true;
+        return this;
+    }
+
     public Map<Class<?>, Class<?>> getMixins() {
         return mixins;
     }
@@ -50,12 +56,19 @@ public class SerializationConfig {
         return shouldUseSnakeCase;
     }
 
+    public boolean shouldAllowNullAsDefaultValueForReadUnknownEnums() {
+        return shouldAllowNullAsDefaultValueForReadUnknownEnums;
+    }
+
+
     @Override
     public String toString() {
         return "SerializationConfig{" +
                 "mixins=" + mixins +
                 ", shouldIgnoreAnySetterAnnotation=" + shouldIgnoreAnySetterAnnotation +
+                ", shouldDisableReadUnknownEnumValuesAsDefaultValue=" + shouldDisableReadUnknownEnumValuesAsDefaultValue +
                 ", shouldUseSnakeCase=" + shouldUseSnakeCase +
+                ", shouldAllowNullAsDefaultValueForReadUnknownEnums=" + shouldAllowNullAsDefaultValueForReadUnknownEnums +
                 '}';
     }
 }

--- a/src/main/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreator.java
+++ b/src/main/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreator.java
@@ -20,6 +20,10 @@ public class SerializationMapperCreator {
         if (!serializationConfig.shouldDisableReadUnknownEnumValuesAsDefaultValue()) {
             objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
         }
+        if (serializationConfig.shouldAllowNullAsDefaultValueForReadUnknownEnums()) {
+            // NOTE: default enum value takes precedence over null
+            objectMapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true);
+        }
 
         serializationConfig.getMixins().forEach(objectMapper::addMixIn);
 


### PR DESCRIPTION
For forward compatibility and prevent deserialization exceptions, allow unknown enums to be deserialized to null