### PR TITLE
Remove usage of deprecated property naming strategy CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES

### DIFF
--- a/src/main/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreator.java
+++ b/src/main/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreator.java
@@ -9,11 +9,8 @@ import com.taboola.rest.api.internal.config.SerializationConfig;
 public class SerializationMapperCreator {
     public static ObjectMapper createObjectMapper(SerializationConfig serializationConfig) {
         ObjectMapper objectMapper = new ObjectMapper();
-        if(serializationConfig.shouldUseSnakeCase()) {
-            objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
-        } else {
-            objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
-        }
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 

--- a/src/test/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreatorTest.java
+++ b/src/test/java/com/taboola/rest/api/internal/serialization/SerializationMapperCreatorTest.java
@@ -27,7 +27,7 @@ public class SerializationMapperCreatorTest {
     public void createObjectMapper_defaultSerializationConfig_objectMapperWithDefaultValues() {
         ObjectMapper objectMapper = SerializationMapperCreator.createObjectMapper(new SerializationConfig());
 
-        Assert.assertEquals("Invalid property naming strategy", PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES, objectMapper.getPropertyNamingStrategy());
+        Assert.assertEquals("Invalid property naming strategy", PropertyNamingStrategy.SNAKE_CASE, objectMapper.getPropertyNamingStrategy());
         Assert.assertEquals("Invalid mixin count", 0, objectMapper.mixInCount());
     }
 


### PR DESCRIPTION
You are using `jackson-databind` in version `2.9.10.4` which has `PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES` deprecated and it's set to `SNAKE_CASE` anyway. So there is no need in `com.taboola.rest.api.internal.serialization.SerializationMapperCreator#createObjectMapper` to check if the `SNAKE_CASE` should be used - in the current implementation the `PropertyNamingStrategy` is always set to `SNAKE_CASE`. Maybe even the whole field `com.taboola.rest.api.internal.config.SerializationConfig#shouldUseSnakeCase` could be deleted but I'm not sure so I didn't do that. 

The problem is that this field (`PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES`) has been removed in a newer version of `jackson-databind` library which we are using in our project.

After applying this change there is need to bump version of `api-java-client-core` in the `backstage-api-java-client` and release new version.